### PR TITLE
Fix Remove unused paragraph end tag

### DIFF
--- a/probable_immunity_web_app/templates/immunity_app/immunity_results.html
+++ b/probable_immunity_web_app/templates/immunity_app/immunity_results.html
@@ -6,7 +6,6 @@
 {% endblock %}
 
 {% block content %}
-    <body>
     {% for illness in illnesses %}
         {% set illness_result_template = 'immunity_app/'
                                         + illness + '/'
@@ -19,5 +18,4 @@
         <a href="{{ url_for('immunity_app.immunity') }}" title="Back to data entry.">Get another estimate of
             immunity.</a>
     </p>
-    </body>
 {% endblock %}

--- a/probable_immunity_web_app/templates/immunity_app/take_data.html
+++ b/probable_immunity_web_app/templates/immunity_app/take_data.html
@@ -9,7 +9,6 @@
   <form method="post">
     {{ form.hidden_tag() }}
     <!-- Common data -->
-    <p>
         <!-- birth_year -->
         {{ form.birth_year.label }}<br>
         {{ form.birth_year(size=32) }}
@@ -27,6 +26,6 @@
             {% include illness_template ignore missing%}
         {% endfor %}
         <br>{{ form.submit }}
-    </p>
   </form>
+
 {% endblock %}


### PR DESCRIPTION
Resolves #28 
Reason for "Remove unused paragraph end tag" HTML validator is there is a nested <p> tag. So I have removed it.

The end tag may be omitted if the <p> element is immediately followed by another <p> element.
Reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p