### PR TITLE
Add github action in place of TravisCI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,19 +15,13 @@ jobs:
         experimental: [false]  # These versions must pass.
 
         include:
-           - os: ubuntu-latest
-             python-version: 3.10-dev
-             experimental: true
+#            - os: ubuntu-latest
+#              python-version: 3.10-dev
+#              experimental: true
 
-           - os: windows-latest
-             python-version: 3.6
-             experimental: true
-           - os: windows-latest
-             python-version: 3.7
-             experimental: true
-           - os: windows-latest
-             python-version: 3.10-dev
-             experimental: true
+#            - os: windows-latest
+#              python-version: 3.10-dev
+#              experimental: true
 
     env:
       GITHUB_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}  # Set token for Coveralls.

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,92 @@
+
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}  # Continue after failures
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: [3.8, 3.9]
+        experimental: [false]  # These versions must pass.
+
+        include:
+           - os: ubuntu-latest
+             python-version: 3.10-dev
+             experimental: true
+
+           - os: windows-latest
+             python-version: 3.6
+             experimental: true
+           - os: windows-latest
+             python-version: 3.7
+             experimental: true
+           - os: windows-latest
+             python-version: 3.10-dev
+             experimental: true
+
+    env:
+      GITHUB_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}  # Set token for Coveralls.
+
+    steps:
+    - uses: actions/checkout@v2  # Checkout repo.
+
+    - name: Set up production Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      if: "!endsWith(matrix.python-version, '-dev')"
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Set up dev Python ${{ matrix.python-version }}
+      uses: deadsnakes/action@v2.1.1
+      if: endsWith(matrix.python-version, '-dev')
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Display python version.
+      run: python --version --version && which python
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -r requirements.txt
+        python -m pip install -r requirements_dev.txt
+        
+    - name: Test with pytest --cov=./ --mypy -vv
+      run: |
+        pytest --cov=./ --mypy -vv
+        coverage xml -i
+        coveralls
+        
+    - name: Codacy Coverage Reporter
+      uses: codacy/codacy-coverage-reporter-action@0.2.0
+      if: matrix.os == 'ubuntu_latest'
+      with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: coverage.xml
+
+    - name: Codecov  # upload
+      uses: codecov/codecov-action@v1.2.1
+      with:
+        files: ./coverage.xml
+        name: codecov-umbrella # Optional.
+        fail_ci_if_error: false # Allow codecov to signal fail rather than action failing.
+        verbose: true # Optional (default = false).
+
+  coveralls_finish:
+      needs: test
+      runs-on: ubuntu-latest
+      steps:
+      - name: Coveralls Finished report
+        uses: AndreMiras/coveralls-python-action@develop
+        with:
+          github-token: ${{ github.token }}
+          parallel: true
+          parallel-finished: true
+          flag-name: github_action_tests
+          base-path: '.'
+          debug: true

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,7 @@ jobs:
         python-version: [3.8, 3.9]
         experimental: [false]  # These versions must pass.
 
-        include:
+#         include:
 #            - os: ubuntu-latest
 #              python-version: 3.10-dev
 #              experimental: true


### PR DESCRIPTION
Replace Travis (which is no longer running for free).
Remove testing on Python 3.6/3.7.